### PR TITLE
extra args for board

### DIFF
--- a/lib/Net/Async/Trello.pm
+++ b/lib/Net/Async/Trello.pm
@@ -109,8 +109,10 @@ Returns a L<Future>.
 sub board {
 	my ($self, %args) = @_;
     my $id = delete $args{id};
+    my $uri = URI->new($self->base_uri . 'board/' . $id);
+    $uri->query_param(%args);
 	$self->http_get(
-		uri => URI->new($self->base_uri . 'board/' . $id)
+		uri => $uri
 	)->transform(
         done => sub {
             Net::Async::Trello::Board->new(


### PR DESCRIPTION
This is to allow sending extra params to Trello's boards/{id} endpoint such as `labels=all`. 